### PR TITLE
Don't report error for interrupted system calls.

### DIFF
--- a/4_optimize_gobwas/server.go
+++ b/4_optimize_gobwas/server.go
@@ -60,7 +60,9 @@ func Start() {
 	for {
 		connections, err := epoller.Wait()
 		if err != nil {
-			log.Printf("Failed to epoll wait %v", err)
+			if err != syscall.EINTR {
+				log.Printf("Failed to epoll wait %v", err)
+			}
 			continue
 		}
 		for _, conn := range connections {


### PR DESCRIPTION
Don't log interrupted system calls since they can happen quite often while waiting for connections, and they're not really an error in our use-case.